### PR TITLE
ci: change service account and fix docker secret

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -61,7 +61,7 @@ jobs:
               uses: google-github-actions/auth@v0
               with:
                   workload_identity_provider: projects/699926043561/locations/global/workloadIdentityPools/github-dev/providers/github-dev-provider
-                  service_account: jarvis-proto@jarvis-dev-268314.iam.gserviceaccount.com
+                  service_account: opa-indykite-plugin@jarvis-dev-268314.iam.gserviceaccount.com
 
             - name: Trivy config scan
               uses: aquasecurity/trivy-action@master
@@ -81,7 +81,7 @@ jobs:
               uses: docker/login-action@v2
               with:
                   username: ${{ secrets.DOCKERHUB_USERNAME }}
-                  password: ${{ secrets.DOCKERHUB_SECRET }}
+                  password: ${{ secrets.DOCKERHUB_PAT }}
 
             - name: Build and Tag docker images
               run: |


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

<!-- _Please make sure to review and check all of these items:_ -->

# Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](https://github.com/indykite/.github/blob/master/commit-message.md)
- [ ] is breaking change

## Description of change
In the background I created a new GCP service account for this repository and replaced the old `jarvis-proto@jarvis-dev-268314.iam.gserviceaccount.com` with a repo specific account in the GCP auth action.
Dockerhub secretname was renamed as well.
<!-- Please provide a description of the change here. -->
